### PR TITLE
Improve debug logging of SAML Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ declare variable $cid := exsaml:generate-correlation-id();
 (: handle SP endpoint to process SAML response in HTTP POST :)
 if ($exist:path = "/SAML2SP")
 then
-    let $log := util:log('info', $cid || ": SAML2SP: processing SAML response")
+    let $log := exsaml:log('info', $cid, "SAML2SP: processing SAML response")
     let $status := exsaml:process-saml-response-post()
-    let $log := util:log('debug', $cid || ": endpoint SAML2SP; status: " || $status/@code)
+    let $log := exsaml:log('debug', $cid, "endpoint SAML2SP; status: " || $status/@code)
     return
         if ($status/@code >= 0) then
             (: forward to page that was requested by the user :)
-            let $debug := util:log("info", $cid || ": Auth success - code " || $status/@code || " - relaystate: " || $status/@relaystate)
+            let $debug := exsaml:log("info", $cid, "Auth success - code " || $status/@code || " - relaystate: " || $status/@relaystate)
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
                     <redirect url="{$status/@relaystate}"/>
@@ -167,7 +167,7 @@ then
 (: if no valid token, redirect to SAML auth :)
 else if (exsaml:is-enabled($cid) and not(exsaml:check-valid-saml-token($cid)))
 then
-    let $debug := exsaml:log('info', $cid || ": controller: no valid token, redirect to SAML auth")
+    let $debug := exsaml:log('info', $cid, "controller: no valid token, redirect to SAML auth")
     let $return-path := "/exist/apps" || $exist:controller || $exist:path
     return
         <dispatch xmlns="http://exist.sourceforge.net/NS/exist">

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -171,6 +171,7 @@ declare function exsaml:process-saml-response-post() {
                     fn:parse-xml-fragment($decode-resp)
 
     let $debug := exsaml:log("debug", "START SAML RESPONSE")
+    let $debug := exsaml:log("debug", $saml-resp)
     let $debug := exsaml:log("debug", fn:serialize($resp))
     let $debug := exsaml:log("debug", "END SAML RESPONSE")
 

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -170,9 +170,9 @@ declare function exsaml:process-saml-response-post() {
                 return
                     fn:parse-xml-fragment($decode-resp)
 
-    let $debug := exsaml:log("debug", "START SAML RESPONSE ")
-    let $debug := exsaml:log("debug", $resp)
-    let $debug := exsaml:log("debug", "END SAML RESPONSE ")
+    let $debug := exsaml:log("debug", "START SAML RESPONSE")
+    let $debug := exsaml:log("debug", fn:serialize($resp))
+    let $debug := exsaml:log("debug", "END SAML RESPONSE")
 
     return
 

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -170,10 +170,11 @@ declare function exsaml:process-saml-response-post() {
                 return
                     fn:parse-xml-fragment($decode-resp)
 
-    let $debug := exsaml:log("debug", "START SAML RESPONSE")
-    let $debug := exsaml:log("debug", $saml-resp)
-    let $debug := exsaml:log("debug", fn:serialize($resp))
-    let $debug := exsaml:log("debug", "END SAML RESPONSE")
+    let $id := util:uuid()
+    let $debug := exsaml:log("debug", "START SAML RESPONSE: " || $id)
+    let $debug := exsaml:log("debug", $id || ": " || $saml-resp)
+    let $debug := exsaml:log("debug", $id || ": " || fn:serialize($resp))
+    let $debug := exsaml:log("debug", "END SAML RESPONSE: " || $id)
 
     return
 

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -65,15 +65,40 @@ declare %private variable $exsaml:status-badauth := "urn:oasis:names:tc:SAML:2.0
 declare variable $exsaml:ERROR :=  xs:QName("saml:error");
 
 
-(: may be used to check if SAML is enabled at all :)
-declare function exsaml:is-enabled() {
-    $exsaml:config/@enabled = "true"
+(:~
+ : Generate a correlation ID.
+ :
+ : This is used for correlating log messages etc.
+ : 
+ : @return the correlation ID.
+ :)
+declare function exsaml:generate-correlation-id() as xs:string {
+    util:uuid()
 };
 
-(: dump current config data :)
-declare function exsaml:info() {
+
+(:~
+ : May be used to check if SAML is enabled at all
+ :
+ : @param $cid An id used for correlating log messages.
+ :
+ : @return true if SAML is enabled, false otherwise.
+ :)
+declare function exsaml:is-enabled($cid as xs:string) {
+    let $result := $exsaml:config/@enabled eq "true"
+    let $_ := exsaml:log("debug", $cid || ": saml is-enabled: " || $result)
+    return
+      $result
+};
+
+(:~
+ : Dump current config data.
+ :
+ : @param $cid An id used for correlating log messages.
+ :)
+declare function exsaml:info($cid as xs:string) {
     map {
-      'enabled': exsaml:is-enabled(),
+      'enabled': exsaml:is-enabled($cid),
       'version': $exsaml:version,
       'hmacAlgorithm': $exsaml:hmac-alg,
       'idpEntity': $exsaml:idp-ent,
@@ -90,61 +115,79 @@ declare function exsaml:info() {
  : This function is called from the controller when a request without valid
  : token is found, so that the user gets sent to the SAML IDP.
  :
- : @param relaystate this is the path component of the resource that the user
+ : @param $cid a correlation id.
+ : @param $relaystate this is the path component of the resource that the user
  :  initially requested, so that she gets sent there after SAML auth.
  :)
-declare function exsaml:build-authnreq-redir-url($relaystate as xs:string) as xs:string {
-    let $log := exsaml:log("info", "building SAML auth request redir-url; relaystate: " || $relaystate)
-    let $req := exsaml:build-saml-authnreq()
-    let $log := exsaml:log("debug", "build-authnreq-redir-url; req: " || $req)
+declare function exsaml:build-authnreq-redir-url($cid as xs:string, $relaystate as xs:string) as xs:string {
+    let $log := exsaml:log("info", $cid || ": building SAML auth request redir-url; relaystate: " || $relaystate)
+    let $req := exsaml:build-saml-authnreq($cid)
+    let $log := exsaml:log("debug", $cid || ": build-authnreq-redir-url; req: " || $req)
 
     (: deflate and base64 encode request :)
     let $ser := fn:serialize($req)
-(:    let $log := exsaml:log("debug", "build-authnreq-redir-url; ser: " || $ser):)
+(:    let $log := exsaml:log("debug", $cid || ": build-authnreq-redir-url; ser: " || $ser):)
     let $bin := util:string-to-binary($ser)
-(:    let $log := exsaml:log("debug", "build-authnreq-redir-url; bin: " || $bin):)
+(:    let $log := exsaml:log("debug", $cid || ": build-authnreq-redir-url; bin: " || $bin):)
     let $zip := compression:deflate($bin, true())
-(:    let $log := exsaml:log("debug", "build-authnreq-redir-url; zip: " || $zip):)
+(:    let $log := exsaml:log("debug", $cid || ": build-authnreq-redir-url; zip: " || $zip):)
     (: urlencode base64 request data :)
     let $urlenc := xmldb:encode($zip cast as xs:string)
 
-    let $log := exsaml:log("debug", "build-authnreq-redir-url; urlenc: " || $urlenc)
+    let $log := exsaml:log("debug", $cid || ": build-authnreq-redir-url; urlenc: " || $urlenc)
 
     return
         $exsaml:idp-uri || "?SAMLRequest=" || $urlenc || "&amp;RelayState=" || xmldb:encode($relaystate)
 };
 
-(: build and return SAML AuthnRequest node :)
-declare %private function exsaml:build-saml-authnreq() as element(samlp:AuthnRequest) {
-    let $id := exsaml:gen-id()
+(:~
+ : Build and return SAML AuthnRequest node.
+ :
+ : @param $cid An id used for correlating log messages.
+ :)
+declare %private function exsaml:build-saml-authnreq($cid as xs:string) as element(samlp:AuthnRequest) {
+    let $reqid := exsaml:gen-id()
     let $instant := fn:current-dateTime()
-    let $store := exsaml:store-authnreqid($id, $instant)
+    let $store := exsaml:store-authnreqid($cid, $reqid, $instant)
     return
-        <samlp:AuthnRequest ID="{$id}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}" AssertionConsumerServiceIndex="0">
+        <samlp:AuthnRequest ID="{$reqid}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}" AssertionConsumerServiceIndex="0">
             <saml:Issuer>{$exsaml:sp-ent}</saml:Issuer>
         </samlp:AuthnRequest>
 };
 
-declare %private function exsaml:store-authnreqid-as-exsol-user($id as xs:string, $instant as xs:string) {
+(:~
+ : Store authreqid.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $reqid The SAML Request ID.
+ : @param $instant the instant.
+ :)
+declare %private function exsaml:store-authnreqid-as-exsol-user($cid as xs:string, $reqid as xs:string, $instant as xs:string) {
     let $create-collection :=
             if (not(xmldb:collection-available($exsaml:saml-coll-reqid)))
             then
-                let $log := exsaml:log("info", "collection " || $exsaml:saml-coll-reqid || " does not exist, attempting to create it")
+                let $log := exsaml:log("info", $cid || ": collection " || $exsaml:saml-coll-reqid || " does not exist, attempting to create it")
                 return
                     xmldb:create-collection("/db/apps/existdb-saml", "saml-request-ids")
             else ()
     return
-        xmldb:store($exsaml:saml-coll-reqid, $id, <reqid>{$instant}</reqid>)
+        xmldb:store($exsaml:saml-coll-reqid, $reqid, <reqid>{$instant}</reqid>)
 };
 
-(: store issued request ids in a collection,  :)
-declare %private function exsaml:store-authnreqid($id as xs:string, $instant as xs:string) {
-    let $log := exsaml:log("info", "storing SAML request id: " || $id || ", date: " || $instant)
+(:~
+ : Store issued request ids in a collection.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $reqid The SAML Request ID.
+ : @param $instant the instant.
+ :)
+declare %private function exsaml:store-authnreqid($cid as xs:string, $reqid as xs:string, $instant as xs:string) {
+    let $log := exsaml:log("info", $cid || ": storing SAML request id: " || $reqid || ", date: " || $instant)
     return
         system:as-user(
                 $exsaml:exsaml-user,
                 $exsaml:exsaml-pass,
-                exsaml:store-authnreqid-as-exsol-user($id, $instant)
+                exsaml:store-authnreqid-as-exsol-user($cid, $reqid, $instant)
         )
 };
 
@@ -156,9 +199,11 @@ declare %private function exsaml:store-authnreqid($id as xs:string, $instant as 
  : authentication is valid, create local DB user and put SAML token into
  : session parameters.  Finally return authentication data to the caller,
  : so the user can be redirected to the requested resource.
+ :
+ : @param $cid An id used for correlating log messages.
  :)
-declare function exsaml:process-saml-response-post() {
-    let $log  := exsaml:log("info", "process-saml-response-post")
+declare function exsaml:process-saml-response-post($cid as xs:string) {
+    let $log  := exsaml:log("info", $cid || ": process-saml-response-post")
     let $saml-resp := request:get-parameter("SAMLResponse", "error")
 
     let $resp :=
@@ -170,22 +215,21 @@ declare function exsaml:process-saml-response-post() {
                 return
                     fn:parse-xml-fragment($decode-resp)
 
-    let $id := util:uuid()
-    let $debug := exsaml:log("debug", "START SAML RESPONSE: " || $id)
-    let $debug := exsaml:log("debug", $id || ": " || $saml-resp)
-    let $debug := exsaml:log("debug", $id || ": " || fn:serialize($resp))
-    let $debug := exsaml:log("debug", "END SAML RESPONSE: " || $id)
+    let $debug := exsaml:log("debug", $cid || ": START SAML RESPONSE")
+    let $debug := exsaml:log("debug", $cid || ": " || $saml-resp)
+    let $debug := exsaml:log("debug", $cid || ": " || fn:serialize($resp))
+    let $debug := exsaml:log("debug", $cid || ": END SAML RESPONSE")
 
     return
 
         if ($resp = "error")
         then
-            error($exsaml:ERROR, "Empty SAML Response", "No SAML response data has been provided")
+            error($exsaml:ERROR, $cid || ": Empty SAML Response: ", "No SAML response data has been provided")
         else
 
             try {
 
-                let $res := exsaml:validate-saml-response($resp)
+                let $res := exsaml:validate-saml-response($cid, $resp)
                 return
                     if ($res/@res lt 0)
                     then
@@ -199,18 +243,18 @@ declare function exsaml:process-saml-response-post() {
                                 (: if we accept IDP-initiated SAML *and* use a forced landing page :)
                                 if ($exsaml:idp-unsolicited and $exsaml:idp-force-rs != "")
                                 then
-                                    let $debug := exsaml:log("debug", "evaluated to: $exsaml:idp-unsolicited and $exsaml:idp-force-rs != ''")
-                                    let $debug := exsaml:log("debug", "$exsaml:idp-force-rs is: " || $exsaml:idp-force-rs || " evaluated: " || string-length($exsaml:idp-force-rs))
+                                    let $debug := exsaml:log("debug", $cid || ": evaluated to: $exsaml:idp-unsolicited and $exsaml:idp-force-rs != ''")
+                                    let $debug := exsaml:log("debug", $cid || ": $exsaml:idp-force-rs is: " || $exsaml:idp-force-rs || " evaluated: " || string-length($exsaml:idp-force-rs))
                                     return
                                         $exsaml:idp-force-rs
                                 (: otherwise accept relaystate from the SAML response :)
                                 else if ($rsin != "")
                                 then
-                                    let $debug := exsaml:log("info", "Relay State as provided by SSO: " || $rsin)
+                                    let $debug := exsaml:log("info", $cid || ": Relay State as provided by SSO: " || $rsin)
                                     return
                                         $rsin
                                 else
-                                    let $debug := exsaml:log("info", "no Relay State provided by SSO, switching to SP fallback relaystate: " || $exsaml:sp-fallback-rs)
+                                    let $debug := exsaml:log("info", $cid || ": no Relay State provided by SSO, switching to SP fallback relaystate: " || $exsaml:sp-fallback-rs)
                                     return
                                         $exsaml:sp-fallback-rs
 
@@ -219,40 +263,47 @@ declare function exsaml:process-saml-response-post() {
                            IF SAML fail, pass enough info to allow meaningful error messages. :)
                         let $auth :=
                                 <authresult code="{$res/@res}" msg="{$res/@msg}" nameid="{$resp/saml:Assertion/saml:Subject/saml:NameID}" relaystate="{$rsout}" authndate="{$resp/saml:Assertion/@IssueInstant}">
-                                    <groups>{exsaml:fetch-saml-attribute-values($exsaml:group-attr, $resp/saml:Assertion) ! <group>{.}</group>}</groups>
+                                    <groups>{exsaml:fetch-saml-attribute-values($cid, $exsaml:group-attr, $resp/saml:Assertion) ! <group>{.}</group>}</groups>
                                 </authresult>
 
                         (: create SAML user if not exists yet :)
                         let $u :=
                                 if ($exsaml:create-user = "true" and $auth/@code >= "0")
                                 then
-                                    exsaml:ensure-saml-user($auth/@nameid)
+                                    exsaml:ensure-saml-user($cid, $auth/@nameid)
                                 else ""
 
                         let $pass := exsaml:create-user-password($auth/@nameid)
                         let $log-in := xmldb:login("/db/apps", $auth/@nameid, $pass, true())
-                        let $log := util:log("info", "login result: " || $log-in || ", " || fn:serialize(sm:id()))
+                        let $log := util:log("info", $cid || ": login result: " || $log-in || ", " || fn:serialize(sm:id()))
 
                         (: put SAML token into browser session :)
                         let $sesstok :=
                                 if ($log-in and $auth/@code >= "0")
                                 then
-                                    exsaml:set-saml-token($auth/@nameid, $auth/@authndate)
+                                    exsaml:set-saml-token($cid, $auth/@nameid, $auth/@authndate)
                                 else ()
 
-                        let $debug := exsaml:log("info", "finished exsaml:process-saml-response-post. auth: ")
-                        let $debug := exsaml:log("info", fn:serialize($auth))
+                        let $debug := exsaml:log("info", $cid || ": finished exsaml:process-saml-response-post. auth: ")
+                        let $debug := exsaml:log("info", $cid || ": " || fn:serialize($auth))
                         return
                             $auth
 
             } catch * {
-                <error>Caught error {$err:code}: {$err:description}. Data: {$err:value}</error>
+                <error cid="{$cid}">Caught error {$err:code}: {$err:description}. Data: {$err:value}</error>
             }
 };
 
-(: validate a SAML response message :)
-declare %private function exsaml:validate-saml-response($resp as node()) as element(exsaml:funcret) {
-    let $log  := exsaml:log("info", "validate-saml-response")
+(:~
+ : Validate a SAML response message.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $resp the XML document containing the SAML Response.
+ :
+ : @return an element indicating the result of the validation.
+ :)
+declare %private function exsaml:validate-saml-response($cid as xs:string, $resp as node()) as element(exsaml:funcret) {
+    let $log  := exsaml:log("info", $cid || ": validate-saml-response")
 
     let $as := $resp/saml:Assertion
     let $sig := $resp/ds:Signature
@@ -263,7 +314,7 @@ declare %private function exsaml:validate-saml-response($resp as node()) as elem
          :)
         if (not($resp/samlp:Status/samlp:StatusCode/@Value = $exsaml:status-success))
         then
-            <exsaml:funcret res="-3" msg="SAML authentication failed" data="{$resp/samlp:Status/samlp:StatusCode/@Value}"/>
+            <exsaml:funcret res="-3" msg="SAML authentication failed" cid="{$cid}" data="{$resp/samlp:Status/samlp:StatusCode/@Value}"/>
 
         (: check that "Issuer" is the expected IDP.  Not stricty required by
          : SAML specs, but adds extra protection against forged SAML responses.
@@ -272,33 +323,40 @@ declare %private function exsaml:validate-saml-response($resp as node()) as elem
         then
             let $msg := "SAML response from unexpected IDP: " || $resp/saml:Issuer
             return
-                <exsaml:funcret res="-6" msg="{$msg}" data="{$resp/saml:Issuer}"/>
+                <exsaml:funcret res="-6" msg="{$msg}" cid="{$cid}" data="{$resp/saml:Issuer}"/>
         
         (: verify response signature if present :)
         (: COMMENTED OUT until crypto-lib issues resolved :)
         (:            else if (boolean($sig) and not(exsaml:verify-response-signature($sig))) then :)
-        (:            <exsaml:funcret res="-4" msg="failed to verify response signature" /> :)
+        (:            <exsaml:funcret res="-4" msg="failed to verify response signature" cid="{$cid}"/> :)
 
         (: must contain at least one assertion :)
         else if (empty($as))
         then
-            <exsaml:funcret res="-5" msg="no assertions present" />
+            <exsaml:funcret res="-5" msg="no assertions present" cid="{$cid}"/>
 
         (: validate all assertions - only first by now :)
         else
-            exsaml:validate-saml-assertion($as)
+            exsaml:validate-saml-assertion($cid, $as)
 };
 
-(: validate a SAML assertion :)
-declare %private function exsaml:validate-saml-assertion($assertion as item()) as element(exsaml:funcret) {
+(:~
+ : Validate a SAML assertion.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $assertion The SAML assertion to validate.
+ :
+ : @return an element indicating the result of the validation.
+ :)
+declare %private function exsaml:validate-saml-assertion($cid as xs:string, $assertion as item()) as element(exsaml:funcret) {
     if (empty($assertion))
     then
-        let $log := exsaml:log("info", "Error: Empty Assertion")
+        let $log := exsaml:log("info", $cid || ": Error: Empty Assertion")
         return
-            <exsaml:funcret res="-19" msg="no assertion present" />
+            <exsaml:funcret res="-19" msg="no assertion present" cid="{$cid}"/>
 
     else
-        let $log := exsaml:log("info", "validate-saml-assertion: " || fn:serialize($assertion))
+        let $log := exsaml:log("info", $cid || ": validate-saml-assertion: " || fn:serialize($assertion))
         let $sig := $assertion/ds:Signature
         let $subj-confirm-data := $assertion/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData
         let $conds := $assertion/saml:Conditions
@@ -312,69 +370,73 @@ declare %private function exsaml:validate-saml-assertion($assertion as item()) a
             then
                 let $msg := "SAML assertion from unexpected IDP: " || $assertion/saml:Issuer
                 return
-                    <exsaml:funcret res="-18" msg="{$msg}" data="{$assertion/saml:Issuer}"/>
+                    <exsaml:funcret res="-18" msg="{$msg}" cid="{$cid}" data="{$assertion/saml:Issuer}"/>
 
             (: verify assertion signature if present :)
 (: COMMENTED OUT until crypto-lib issues resolved :)
-(:            else if (boolean($sig) and not(exsaml:verify-assertion-signature($assertion))) then :)
-(:                <exsaml:funcret res="-10" msg="failed to verify assertion signature" /> :)
+(:            else if (boolean($sig) and not(exsaml:verify-assertion-signature($cid, $assertion))) then :)
+(:                <exsaml:funcret res="-10" msg="failed to verify assertion signature" cid="{$cid}"/> :)
 
             (: maybe verify SubjectConfirmation/@Method :)
 
             (: verify SubjectConfirmationData/@Recipient is SP URL ($sp-uri) :)
             else if (not($subj-confirm-data/@Recipient = $exsaml:sp-uri))
             then
-                <exsaml:funcret res="-11" msg="assertion not for me" data="{$subj-confirm-data/@Recipient}"/>
+                <exsaml:funcret res="-11" msg="assertion not for me" cid="{$cid}" data="{$subj-confirm-data/@Recipient}"/>
 
             (: verify SubjectConfirmationData/@NotOnOrAfter is not later than now :)
             else if (xs:dateTime(fn:current-dateTime()) ge xs:dateTime($subj-confirm-data/@NotOnOrAfter))
             then
-                <exsaml:funcret res="-12" msg="assertion no longer valid" data="{$subj-confirm-data/@NotOnOrAfter}"/>
+                <exsaml:funcret res="-12" msg="assertion no longer valid" cid="{$cid}" data="{$subj-confirm-data/@NotOnOrAfter}"/>
 
             (: verify SubjectConfirmationData/@InResponseTo is present in the SAML response :)
             else if (not($reqid))
             then
                 if ($exsaml:idp-unsolicited)
                 then
-                    <exsaml:funcret res="1" msg="accept unsolicited SAML response"/>
+                    <exsaml:funcret res="1" msg="accept unsolicited SAML response" cid="{$cid}"/>
                 else
-                    <exsaml:funcret res="-17" msg="reject unsolicited SAML response"/>
+                    <exsaml:funcret res="-17" msg="reject unsolicited SAML response" cid="{$cid}"/>
 
             (: else verify SubjectConfirmationData/@InResponseTo equal to orig AuthnRequest ID :)
-            else if (not(exsaml:check-authnreqid($reqid)))
+            else if (not(exsaml:check-authnreqid($cid, $reqid)))
             then
-                <exsaml:funcret res="-13" msg="did not send this SAML request" data="{$subj-confirm-data/@InResponseTo}"/>
+                <exsaml:funcret res="-13" msg="did not send this SAML request" cid="{$cid}" data="{$subj-confirm-data/@InResponseTo}"/>
 
             (: verify assertions are valid in other respects - none yet :)
 
             (: verify Conditions/@NotBefore is not earlier than now :)
             else if (xs:dateTime(fn:current-dateTime()) lt xs:dateTime($conds/@NotBefore))
             then
-                <exsaml:funcret res="-14" msg="condition not yet valid" data="{$conds/@NotBefore}"/>
+                <exsaml:funcret res="-14" msg="condition not yet valid" cid="{$cid}" data="{$conds/@NotBefore}"/>
 
             (: verify Conditions/@NotOnOrAfter is not later than now :)
             else if (xs:dateTime(fn:current-dateTime()) ge xs:dateTime($conds/@NotOnOrAfter))
             then
-                <exsaml:funcret res="-15" msg="condition no longer valid" data="{$conds/@NotOnOrAfter}"/>
+                <exsaml:funcret res="-15" msg="condition no longer valid" cid="{$cid}" data="{$conds/@NotOnOrAfter}"/>
 
             (: verify Conditions/AudienceRestriction/Audience is myself ($sp-ent) :)
             else if (not($conds/saml:AudienceRestriction/saml:Audience = $exsaml:sp-ent))
             then
-                <exsaml:funcret res="-16" msg="audience not for me" data="{$conds/saml:AudienceRestriction/saml:Audience}"/>
+                <exsaml:funcret res="-16" msg="audience not for me" cid="{$cid}" data="{$conds/saml:AudienceRestriction/saml:Audience}"/>
 
             else
-                <exsaml:funcret res="0" msg="ok" />
+                <exsaml:funcret res="0" msg="ok" cid="{$cid}"/>
 };
 
-(: retrieve issued SAML request id and delete if answered :)
-declare %private function exsaml:check-authnreqid($reqid as xs:string) as xs:string {
-    let $log := exsaml:log("info", "verifying SAML request id: " || $reqid)
+(:~
+ : Retrieve issued SAML request id and delete if answered.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $reqid the SAML Request ID.
+ :
+ : @param true if the SAML Request ID is valid, false otherwise. 
+ :)
+declare %private function exsaml:check-authnreqid($cid as xs:string, $reqid as xs:string) as xs:boolean {
+    let $log := exsaml:log("info", $cid || ": verifying SAML request: reqid: " || $reqid)
     return
-        if (system:as-user($exsaml:exsaml-user, $exsaml:exsaml-pass,
-                exists(doc($exsaml:saml-coll-reqid || "/" || $reqid)) and empty(xmldb:remove($exsaml:saml-coll-reqid, $reqid))))
-        then
-            $reqid
-        else ""
+        system:as-user($exsaml:exsaml-user, $exsaml:exsaml-pass,
+                exists(doc($exsaml:saml-coll-reqid || "/" || $reqid)) and empty(xmldb:remove($exsaml:saml-coll-reqid, $reqid)))
 };
 
 (: verify XML signature of a SAML response :)
@@ -392,9 +454,16 @@ declare %private function exsaml:verify-response-signature($resp as item()) as x
                 false()
 };
 
-(: verify XML signature of a SAML assertion :)
-declare %private function exsaml:verify-assertion-signature($assertion as item()) as xs:boolean {
-    let $log  := exsaml:log("debug", "verify-assertion-signature " || $assertion)
+(:~
+ : Verify XML signature of a SAML assertion.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $assertion The SAML assertion to validate the signature of.
+ :
+ : @return true of the signature is valid, false otherwise.
+ :)
+declare %private function exsaml:verify-assertion-signature($cid as xs:string, $assertion as item()) as xs:boolean {
+    let $log  := exsaml:log("debug", "verify-assertion-signature: " || $cid || ": " || $assertion)
     return
         (: if $idp-certfile is configured, use that to validate XML signature :)
         if ($exsaml:idp-certfile != "")
@@ -402,36 +471,50 @@ declare %private function exsaml:verify-assertion-signature($assertion as item()
 (:            crypto:validate-signature-by-certfile($assertion, $exsaml:idp-certfile):)
             true()
         else
-            let $log  := exsaml:log("info", "cert to verify assertion signature is missing - could not verify signature! ")
+            let $log  := exsaml:log("info", "cert to verify assertion signature is missing - could not verify signature: " || $cid)
             return
                 false()
 };
 
-(: Fetch the named SAML attribute values from a SAML assertion.  This is
-   used to get group membership of an authenticated user, which gets passed
-   as SAML attribute assertions by the IDP :)
-declare %private function exsaml:fetch-saml-attribute-values($attrname as xs:string, $as as node()) as xs:string* {
-    let $log := exsaml:log("debug", "fetch-saml-attribute " || $attrname || ", " || fn:serialize($as))
+(:~
+ : Fetch the named SAML attribute values from a SAML assertion.
+ : 
+ : This is used to get group membership of an authenticated user,
+ : which gets passed as SAML attribute assertions by the IDP
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $attrname the attribute name to fetch values for.
+ : @param $as the SAML Assertion.
+ :
+ : @return zero or more values from the SAML attribute.
+ :)
+declare %private function exsaml:fetch-saml-attribute-values($cid as xs:string, $attrname as xs:string, $as as element(saml:Assertion)) as xs:string* {
+    let $log := exsaml:log("debug", $cid || ": fetch-saml-attribute " || $attrname || ", " || fn:serialize($as))
     let $seq :=
         for $a in $as/saml:AttributeStatement/saml:Attribute[@Name eq $attrname]/saml:AttributeValue
         return $a/text()
-    let $log := exsaml:log("debug", "fetch-saml-attribute: " || fn:serialize($seq))
+    let $log := exsaml:log("debug", $cid || ": fetch-saml-attribute: " || fn:serialize($seq))
     return
         $seq
 };
 
-(: This function is used to create the named DB user on the fly if the
-   account does not exist yet.  Since we rely on SAML to assert that a
-   certain username is valid, we have no list of usernames upfront, but
-   create them on the fly.  This allows to store per-user preferences and
-   settings. :)
-declare %private function exsaml:ensure-saml-user($nameid as xs:string) {
+(:~
+ : This function is used to create the named DB user on the fly if the
+ : account does not exist yet.  Since we rely on SAML to assert that a
+ : certain username is valid, we have no list of usernames upfront, but
+ : create them on the fly.  This allows to store per-user preferences and
+ : settings.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $nameid the name for the user account.
+ :)
+declare %private function exsaml:ensure-saml-user($cid as xs:string, $nameid as xs:string) {
     let $pass := exsaml:create-user-password($nameid)
     return
         (: run as user exsaml, group dba :)
         system:as-user($exsaml:exsaml-user, $exsaml:exsaml-pass,
                        if (not(sm:user-exists($nameid))
-                           and exsaml:log("info", "create new user account " || $nameid || ", group " || $exsaml:user-group))
+                           and exsaml:log("info", $cid || ": create new user account " || $nameid || ", group " || $exsaml:user-group))
                        then
                            sm:create-account($nameid, $pass, $exsaml:user-group, ())
                        else ()
@@ -452,20 +535,22 @@ declare %private function exsaml:create-user-password($nameid as xs:string) {
 (:~
  : Check whether a SAML token exists and is valid.  Return boolean.
  : This is called from the controller(s) to check if access should be granted.
+ :
+ : @param $cid An id used for correlating log messages.
  :)
-declare function exsaml:check-valid-saml-token() as xs:boolean {
+declare function exsaml:check-valid-saml-token($cid as xs:string) as xs:boolean {
     let $raw  := session:get-attribute($exsaml:token-name)
-    let $log  := exsaml:log("debug", "checking saml token, name: " || $exsaml:token-name || ", value: " || $raw)
+    let $log  := exsaml:log("debug", $cid || ": checking saml token, name: " || $exsaml:token-name || ", value: " || $raw)
 
     let $tokdata := fn:tokenize($raw, $exsaml:token-separator)
     return
-        if (empty($raw) and exsaml:log("info", "no token found"))
+        if (empty($raw) and exsaml:log("info", $cid || ": no token found"))
         then
             false()
-        else if (not($tokdata[3] eq exsaml:hmac-tokval($tokdata[1] || $exsaml:token-separator || $tokdata[2])) and exsaml:log("info", "token is invalid"))
+        else if (not($tokdata[3] eq exsaml:hmac-tokval($cid, $tokdata[1] || $exsaml:token-separator || $tokdata[2])) and exsaml:log("info", $cid || ": token is invalid"))
         then
             false()
-        else if (xs:dateTime(fn:current-dateTime()) gt xs:dateTime($tokdata[2]) and exsaml:log("info", "token has expired"))
+        else if (xs:dateTime(fn:current-dateTime()) gt xs:dateTime($tokdata[2]) and exsaml:log("info", $cid || ": token has expired"))
         then
             false()
         else
@@ -476,39 +561,61 @@ declare function exsaml:check-valid-saml-token() as xs:boolean {
  : Invalidate a SAML token, by creating one with expire date in the past,
  : so that it will fail token expiration checks.
  : This is called from the controller(s) upon user logout.
+ :
+ : @param $cid An id used for correlating log messages.
  :)
-declare function exsaml:invalidate-saml-token() as empty-sequence() {
+declare function exsaml:invalidate-saml-token($cid as xs:string) as empty-sequence() {
     let $user := sm:id()/sm:id/sm:real/sm:username
-    let $tok  := exsaml:build-string-token($user, "1970-01-01T00:00:00")
-    let $hmac := exsaml:hmac-tokval($tok)
-    let $log  := exsaml:log("info", "invalidate saml token for: " || $user || ", hmac: " || $hmac)
+    let $tok  := exsaml:build-string-token($cid, $user, "1970-01-01T00:00:00")
+    let $hmac := exsaml:hmac-tokval($cid, $tok)
+    let $log  := exsaml:log("info", $cid || ": invalidate saml token for: " || $user || ", hmac: " || $hmac)
     return
         session:set-attribute($exsaml:token-name, $tok || $exsaml:token-separator || $hmac)
 };
 
-(: return the HMAC of the string token passed in :)
-declare %private function exsaml:hmac-tokval($tokval as xs:string) as xs:string {
-    let $log  := exsaml:log("debug", "hmac-tokval; t: " || $tokval || ", key: " || $exsaml:hmac-key)
+(:~ Return the HMAC of the string token passed in.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $tokval the token.
+ :
+ : @return the HMAC.
+ :)
+declare %private function exsaml:hmac-tokval($cid as xs:string, $tokval as xs:string) as xs:string {
+    let $log  := exsaml:log("debug", $cid || ": hmac-tokval; t: " || $tokval || ", key: " || $exsaml:hmac-key)
     let $key  := $exsaml:hmac-key || ""
     let $alg  := $exsaml:hmac-alg || ""
     return
         crypto:hmac($tokval, $key, $alg, "hex")
 };
 
-(: build string token: join nameid and validto by $exsaml:token-separator :)
-declare %private function exsaml:build-string-token($nameid as xs:string, $validto as xs:string) as xs:string {
-    let $log  := exsaml:log("debug", "build-string-token; n: " || $nameid || ", v: " || $validto)
+(:~
+ : Build string token: join nameid and validto by $exsaml:token-separator.
+ :
+ : @param $cid An id used for correlating log messages.
+ : @param $nameid the user name.
+ : @param $validto the expiry date in ISO format.
+ :
+ : @return the token.
+ :)
+declare %private function exsaml:build-string-token($cid as xs:string, $nameid as xs:string, $validto as xs:string) as xs:string {
+    let $log  := exsaml:log("debug", $cid || ": build-string-token; n: " || $nameid || ", v: " || $validto)
     return
         $nameid || $exsaml:token-separator || $validto
 };
 
-(: build and HMAC token and stuff into browser session :)
-declare %private function exsaml:set-saml-token($nameid as xs:string, $authndate as xs:string) as empty-sequence() {
+(:~
+ : Build and HMAC token and stuff into browser session.
+ : 
+ : @param $cid An id used for correlating log messages.
+ : @param $nameid the user name.
+ : @param $authndate the auth date.
+ :)
+declare %private function exsaml:set-saml-token($cid as xs:string, $nameid as xs:string, $authndate as xs:string) as empty-sequence() {
     let $validto := xs:dateTime($authndate) + xs:dayTimeDuration("PT" || $exsaml:token-minutes || "M")
 
-    let $tok := exsaml:build-string-token($nameid, $validto)
-    let $hmac := exsaml:hmac-tokval($tok)
-    let $log  := exsaml:log("info", "set saml token for: " || $nameid || ", authndate: " || $authndate || ", valid until: " || $validto || ", hmac: " || $hmac)
+    let $tok := exsaml:build-string-token($cid, $nameid, $validto)
+    let $hmac := exsaml:hmac-tokval($cid, $tok)
+    let $log  := exsaml:log("info", $cid || ": set saml token for: " || $nameid || ", authndate: " || $authndate || ", valid until: " || $validto || ", hmac: " || $hmac)
     return
         session:set-attribute($exsaml:token-name, $tok || $exsaml:token-separator || $hmac)
 };
@@ -517,26 +624,26 @@ declare %private function exsaml:set-saml-token($nameid as xs:string, $authndate
 (: ==== FUNCTIONS TO FAKE A SAML IDP (testing only) ==== :)
 
 (: process SAML AuthnRequest, return SAML Response via POST :)
-declare function exsaml:process-saml-request() as element(html){
-    let $log  := exsaml:log("debug", "process-saml-request")
+declare function exsaml:process-saml-request($cid as xs:string) as element(html) {
+    let $log  := exsaml:log("debug", $cid || ": process-saml-request")
     let $raw  := request:get-parameter("SAMLRequest", "")
-    let $log  := exsaml:log("debug", "process-saml-request; raw: " || $raw)
+    let $log  := exsaml:log("debug", $cid || ": process-saml-request; raw: " || $raw)
     let $uncomp := compression:inflate($raw, true())
-    let $log  := exsaml:log("debug", "process-saml-request; uncomp: " || $uncomp)
+    let $log  := exsaml:log("debug", $cid || ": process-saml-request; uncomp: " || $uncomp)
     let $strg := util:base64-decode($uncomp)
-    let $log  := exsaml:log("debug", "process-saml-request; strg: " || $strg)
+    let $log  := exsaml:log("debug", $cid || ": process-saml-request; strg: " || $strg)
     let $req  := fn:parse-xml-fragment($strg)
-    let $log  := exsaml:log("debug", "process-saml-request; req: " || $req)
+    let $log  := exsaml:log("debug", $cid || ": process-saml-request; req: " || $req)
     let $rs   := request:get-parameter("RelayState", false())
 
-    let $resp := exsaml:fake-idp-response($req, $rs)
+    let $resp := exsaml:fake-idp-response($cid, $req, $rs)
     return $resp
 };
 
 (: fake SAML IDP response: build response and return via XHTML autosubmit form :)
-declare %private function exsaml:fake-idp-response($req as node(), $rs as xs:string) as element(html) {
-    let $log := exsaml:log("debug", "fake-idp-response")
-    let $resp := exsaml:build-saml-fakeresp($req)
+declare %private function exsaml:fake-idp-response($cid as xs:string, $req as node(), $rs as xs:string) as element(html) {
+    let $log := exsaml:log("debug", $cid || ": fake-idp-response")
+    let $resp := exsaml:build-saml-fakeresp($cid, $req)
     let $b64resp := util:base64-encode(fn:serialize($resp))
     return
         <html>
@@ -544,6 +651,7 @@ declare %private function exsaml:fake-idp-response($req as node(), $rs as xs:str
             <body onload="document.forms.samlform.submit()">
                 <noscript><p><strong>Note:</strong> Since your browser does not support Javascript, you must press the Submit button once to proceed.</p></noscript>
                 <form id="samlform" method="post" action="{$exsaml:sp-uri}">
+                    <input type="hidden" name="cid" value="{$cid}" />
                     <input type="hidden" name="SAMLResponse" value="{$b64resp}" />
                     <input type="hidden" name="RelayState" value="{$rs}" />
                     <input type="submit" value="Submit" />
@@ -553,7 +661,7 @@ declare %private function exsaml:fake-idp-response($req as node(), $rs as xs:str
 };
 
 (: return a fake SAML response node :)
-declare %private function exsaml:build-saml-fakeresp($req as node()) as element(samlp:Response) {
+declare %private function exsaml:build-saml-fakeresp($cid as xs:string, $req as node()) as element(samlp:Response) {
     let $reqid := $req/@ID
     let $status :=
             if ($exsaml:fake-result = "true")


### PR DESCRIPTION
1. Bugfix - previously only text nodes were logged.
2. Feature - A Correlation ID to make debugging easier and enable to to correlate log lines and requests and responses.