### PR TITLE
Make Assertion Consumer Service configurable

### DIFF
--- a/content/config-exsaml.xml
+++ b/content/config-exsaml.xml
@@ -12,10 +12,11 @@
     <!-- sp (service provider) is our local eXist DB -->
     <!--   @entity: just a namestring in URI format -->
     <!--   @endpoint: our HTTP endpoint to post SAML responses to -->
+    <!--   @assertion-consumer-service-index: Indirectly identifies the location to which the <Response> message should be returned to the requester by the IDP. -->
     <!--   @fallback-relaystate: used if IdP does not send a relaystate -->
 
     <!-- SERVICE PROVIDER CONFIGURATION  -->
-    <sp entity="https://service-provider.org" endpoint="https://service-provider.org/SAML2SP" fallback-relaystate="https://service-provider.org"/>
+     <sp entity="https://service-provider.org" endpoint="https://service-provider.org/SAML2SP" assertion-consumer-service-index="0" fallback-relaystate="https://service-provider.org"/>
 
 
     <!-- IDENTITY PROVIDER -->

--- a/content/config-exsaml.xml
+++ b/content/config-exsaml.xml
@@ -12,7 +12,12 @@
     <!-- sp (service provider) is our local eXist DB -->
     <!--   @entity: just a namestring in URI format -->
     <!--   @endpoint: our HTTP endpoint to post SAML responses to -->
-    <!--   @assertion-consumer-service-index: Indirectly identifies the location to which the <Response> message should be returned to the requester by the IDP. -->
+    <!--   @assertion-consumer-service-index: Indirectly identifies the location
+               to which the <Response> message should be returned to the requester by the IDP.
+               This is set on the Auth Request as the attributes 'AssertionConsumerServiceIndex'.
+               If the 'assertion-consumer-service-index' value is omitted from the config,
+               then an 'AssertionConsumerServiceURL' attribute holding the @endpoint value will
+               be set on the Auth Request instead. -->
     <!--   @fallback-relaystate: used if IdP does not send a relaystate -->
 
     <!-- SERVICE PROVIDER CONFIGURATION  -->

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -30,6 +30,7 @@ declare %private variable $exsaml:config   := doc("config-exsaml.xml")/config;
 
 declare %private variable $exsaml:sp-ent   := data($exsaml:config/sp/@entity);
 declare %private variable $exsaml:sp-uri   := data($exsaml:config/sp/@endpoint);
+declare %private variable $exsaml:sp-assertion-consumer-service-index := $exsaml:config/sp/@assertion-consumer-service-index ! xs:integer(.);
 declare %private variable $exsaml:sp-fallback-rs := data($exsaml:config/sp/@fallback-relaystate);
 declare %private variable $exsaml:idp-ent  := data($exsaml:config/idp/@entity);
 declare %private variable $exsaml:idp-uri  := data($exsaml:config/idp/@endpoint);
@@ -151,7 +152,7 @@ declare %private function exsaml:build-saml-authnreq($cid as xs:string) as eleme
     let $instant := fn:current-dateTime()
     let $store := exsaml:store-authnreqid($cid, $reqid, $instant)
     return
-        <samlp:AuthnRequest ID="{$reqid}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}" AssertionConsumerServiceIndex="0">
+        <samlp:AuthnRequest ID="{$reqid}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}" AssertionConsumerServiceIndex="{$exsaml:sp-assertion-consumer-service-index}">
             <saml:Issuer>{$exsaml:sp-ent}</saml:Issuer>
         </samlp:AuthnRequest>
 };

--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -152,7 +152,14 @@ declare %private function exsaml:build-saml-authnreq($cid as xs:string) as eleme
     let $instant := fn:current-dateTime()
     let $store := exsaml:store-authnreqid($cid, $reqid, $instant)
     return
-        <samlp:AuthnRequest ID="{$reqid}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}" AssertionConsumerServiceIndex="{$exsaml:sp-assertion-consumer-service-index}">
+        <samlp:AuthnRequest ID="{$reqid}" Version="{$exsaml:saml-version}" IssueInstant="{$instant}">
+        {
+            if (fn:exists($exsaml:sp-assertion-consumer-service-index))
+            then
+                attribute AssertionConsumerServiceIndex { $exsaml:sp-assertion-consumer-service-index }
+            else
+                attribute AssertionConsumerServiceURL { $exsaml:sp-uri }
+        }
             <saml:Issuer>{$exsaml:sp-ent}</saml:Issuer>
         </samlp:AuthnRequest>
 };


### PR DESCRIPTION
1. Previously the value of `AssertionConsumerServiceIndex` was hard-coded to `0`, and is dependent on your IDP setup. It is now configurable from the `config-exsaml.xml` file (where it still defaults to `0`).
2. Previously it was not possible to work with an IDP that expected an `AssertionConsumerServiceURL` instead of an `AssertionConsumerServiceIndex`. Which is permitted by the SAML Core spec. This adds that feature.