### PR TITLE
The SAML response should be a well-formed XML document

### DIFF
--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -214,7 +214,7 @@ declare function exsaml:process-saml-response-post($cid as xs:string) {
             else
                 let $decode-resp := util:base64-decode($saml-resp)
                 return
-                    fn:parse-xml-fragment($decode-resp)
+                    fn:parse-xml($decode-resp)
 
     let $debug := exsaml:log("debug", $cid, "START SAML RESPONSE")
     let $debug := exsaml:log("debug", $cid, $saml-resp)
@@ -637,7 +637,7 @@ declare function exsaml:process-saml-request($cid as xs:string) as element(html)
     let $log  := exsaml:log("debug", $cid, "process-saml-request; uncomp: " || $uncomp)
     let $strg := util:base64-decode($uncomp)
     let $log  := exsaml:log("debug", $cid, "process-saml-request; strg: " || $strg)
-    let $req  := fn:parse-xml-fragment($strg)
+    let $req  := fn:parse-xml($strg)
     let $log  := exsaml:log("debug", $cid, "process-saml-request; req: " || $req)
     let $rs   := request:get-parameter("RelayState", false())
 


### PR DESCRIPTION
The SAML response should be a well-formed XML document and not a fragment, so we should not try and parse it as a fragment.

Additionally there is a current bug in eXist-db whereby if the SAML response includes an XML Declaration then `fn:parse-xml-fragment#1` will throw an incorrect error, for example the following valid XQuery raises an error in eXist-db:
```xquery
fn:parse-xml-fragment('<?xml version="1.0" encoding="UTF-8" ?>
<hello>world</hello>')
```