### PR TITLE
Fix type error when comparing untyped with integer

### DIFF
--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -232,7 +232,7 @@ declare function exsaml:process-saml-response-post($cid as xs:string) {
 
                 let $res := exsaml:validate-saml-response($cid, $resp)
                 return
-                    if ($res/@res lt 0)
+                    if (xs:integer($res/@res) lt 0)
                     then
                         (: validate-saml-response returned a negative @res value which is an error code, so just return it:)
                         $res
@@ -268,7 +268,7 @@ declare function exsaml:process-saml-response-post($cid as xs:string) {
 
                         (: create SAML user if not exists yet :)
                         let $u :=
-                                if ($exsaml:create-user = "true" and $auth/@code >= "0")
+                                if ($exsaml:create-user = "true" and xs:integer($auth/@code) ge 0)
                                 then
                                     exsaml:ensure-saml-user($cid, $auth/@nameid)
                                 else ""
@@ -279,7 +279,7 @@ declare function exsaml:process-saml-response-post($cid as xs:string) {
 
                         (: put SAML token into browser session :)
                         let $sesstok :=
-                                if ($log-in and $auth/@code >= "0")
+                                if ($log-in and xs:integer($auth/@code) ge 0)
                                 then
                                     exsaml:set-saml-token($cid, $auth/@nameid, $auth/@authndate)
                                 else ()


### PR DESCRIPTION
I suspect this has been made more XQuery spec compliant in newer versions of eXist-db. Without this patch I see type errors in eXist-db 7.x.x.