### PR TITLE
Fix to correctly extract the SAML Response

### DIFF
--- a/content/exsaml.xqm
+++ b/content/exsaml.xqm
@@ -356,7 +356,7 @@ declare %private function exsaml:validate-saml-response($cid as xs:string, $resp
  :
  : @return an element indicating the result of the validation.
  :)
-declare %private function exsaml:validate-saml-assertion($cid as xs:string, $assertion as item()) as element(exsaml:funcret) {
+declare %private function exsaml:validate-saml-assertion($cid as xs:string, $assertion as element(saml:Assertion)) as element(exsaml:funcret) {
     if (empty($assertion))
     then
         let $log := exsaml:log("info", $cid, "Error: Empty Assertion")


### PR DESCRIPTION
The SAML response is extracted from the HTTP Request Body via `fn:parse-xml-fragment#1`. The existing XQuery code was expecting `fn:parse-xml-fragment($resp)` to return a value of type `element(samlp:Response)`, however that is incorrect in theory, and also does not work in practice (tested on eXist-db 6.x.x and 7.x.x). The W3 spec for the XQuery function `fn:parse-xml-fragment#1` specifies that a value of type `document-node(element(samlp:Response))` will be returned. This PR fixes that bug.